### PR TITLE
Added a sub-category to Oxocarbon's parent panel + Made sub-category additions dynamic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Provide a general summary of your changes in the Title above -->
+
+#### Description
+<!-- Describe your changes in detail -->
+
+#### Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
+
+#### Screenshots (if appropriate):
+
+#### Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Non-Functional Change (non-user facing changes)
+
+#### Checklist:
+<!-- Go over all the following points, and put an `x` in all the boxes . -->
+<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
+- [ ] I updated the version.
+- [ ] I updated the changelog with the new functionality.

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/OxocarbonManager.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/OxocarbonManager.kt
@@ -1,6 +1,7 @@
 package com.github.lynxie.oxocarbon
 
 import com.github.lynxie.oxocarbon.panels.AppearanceSettingsPanel
+import com.github.lynxie.oxocarbon.panels.CustomThemeSettingsPanel
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.extensions.PluginId
 import java.util.*
@@ -8,9 +9,11 @@ import java.util.*
 class OxocarbonManager {
 
     companion object {
+
         private const val PLUGIN_ID : String = "com.github.lynxie.Oxocarbon"
 
         var appearanceSettingsPanel: AppearanceSettingsPanel? = null
+        var customThemeSettingsPanel: CustomThemeSettingsPanel? = null
         
         val currentVersion : String
             get() = Objects.requireNonNull(PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "")

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/enums/SettingsCategory.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/enums/SettingsCategory.kt
@@ -15,7 +15,7 @@ enum class SettingsCategory(val configurable: Configurable, val categoryName: St
     companion object {
         fun getAllConfigurables(): Array<Configurable> {
             val array : Array<Configurable> = emptyArray()
-            values().forEach { array[it.ordinal] = it.configurable }
+            entries.forEach { array[it.ordinal] = it.configurable }
             return array
         }
 

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/enums/SettingsCategory.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/enums/SettingsCategory.kt
@@ -1,10 +1,14 @@
 package com.github.lynxie.oxocarbon.enums
 
 import com.github.lynxie.oxocarbon.settings.configurable.AppearanceSettingsConfigurable
+import com.github.lynxie.oxocarbon.settings.configurable.CustomThemeSettingsConfigurable
+import com.github.lynxie.oxocarbon.settings.configurable.OxocarbonParentSettingsConfigurable
 import com.intellij.openapi.options.Configurable
 
-enum class SettingsCategory(val configurable: Configurable, val id: String) {
-    APPEARANCE(AppearanceSettingsConfigurable(), "2ea70210-3f9b-476a-9733-87d1b9864d67")
+enum class SettingsCategory(val configurable: Configurable, val categoryName: String, val id: String) {
+    PARENT(OxocarbonParentSettingsConfigurable(), "Oxocarbon Settings", "6f004dfd-8730-4721-90c6-92d762bd0ffd"),
+    APPEARANCE(AppearanceSettingsConfigurable(), "Appearance","2ea70210-3f9b-476a-9733-87d1b9864d67"),
+    CUSTOM_THEME(CustomThemeSettingsConfigurable(), "Custom Theme","1c3ed063-89a6-463e-95ab-358b5fdafa95")
 
     ;
 
@@ -13,6 +17,11 @@ enum class SettingsCategory(val configurable: Configurable, val id: String) {
             val array : Array<Configurable> = emptyArray()
             values().forEach { array[it.ordinal] = it.configurable }
             return array
+        }
+
+        @OptIn(ExperimentalStdlibApi::class)
+        fun getSettingsCategoryByName(name: String): SettingsCategory {
+            return entries.first { it.categoryName == name }
         }
     }
 }

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/panels/CustomThemeSettingsPanel.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/panels/CustomThemeSettingsPanel.kt
@@ -1,0 +1,16 @@
+package com.github.lynxie.oxocarbon.panels
+
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JPanel
+
+class CustomThemeSettingsPanel {
+
+    val panel : JPanel
+
+    init {
+        panel = FormBuilder.createFormBuilder()
+            .setFormLeftIndent(0)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+    }
+}

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/panels/SettingsParentPanel.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/panels/SettingsParentPanel.kt
@@ -27,7 +27,7 @@ class SettingsParentPanel {
      */
     private fun initialiseActionLinks(): JPanel {
         val formBuilder = FormBuilder.createFormBuilder()
-        SettingsCategory.values().forEach { category ->
+        SettingsCategory.entries.forEach { category ->
             if (category.categoryName != SettingsCategory.PARENT.categoryName) {
                 formBuilder.addComponent(ActionLink(category.categoryName))
             }

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/CustomThemeSettings.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/CustomThemeSettings.kt
@@ -1,0 +1,20 @@
+package com.github.lynxie.oxocarbon.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+class CustomThemeSettings private constructor() : PersistentStateComponent<CustomThemeSettings> {
+
+
+    override fun getState() = this
+
+    override fun loadState(state: CustomThemeSettings) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    companion object {
+        val instance: CustomThemeSettings
+            get() = ApplicationManager.getApplication().getService(CustomThemeSettings::class.java)
+    }
+}

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/configurable/AppearanceSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/configurable/AppearanceSettingsConfigurable.kt
@@ -1,6 +1,7 @@
 package com.github.lynxie.oxocarbon.settings.configurable
 
 import com.github.lynxie.oxocarbon.OxocarbonManager
+import com.github.lynxie.oxocarbon.enums.SettingsCategory
 import com.github.lynxie.oxocarbon.panels.AppearanceSettingsPanel
 import com.github.lynxie.oxocarbon.settings.ThemeSettings
 import com.intellij.openapi.options.SearchableConfigurable
@@ -12,11 +13,11 @@ class AppearanceSettingsConfigurable : SearchableConfigurable {
     private var appearanceSettingsPanel: AppearanceSettingsPanel? = null
 
     override fun getDisplayName(): String {
-        return "Oxocarbon"
+        return SettingsCategory.APPEARANCE.categoryName
     }
 
     override fun getId(): String {
-        return "2ea70210-3f9b-476a-9733-87d1b9864d67"
+        return SettingsCategory.APPEARANCE.id
     }
 
     override fun createComponent(): JComponent {

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/configurable/CustomThemeSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/configurable/CustomThemeSettingsConfigurable.kt
@@ -1,0 +1,38 @@
+package com.github.lynxie.oxocarbon.settings.configurable
+
+import com.github.lynxie.oxocarbon.OxocarbonManager
+import com.github.lynxie.oxocarbon.enums.SettingsCategory
+import com.github.lynxie.oxocarbon.panels.CustomThemeSettingsPanel
+import com.intellij.openapi.options.SearchableConfigurable
+import javax.swing.JComponent
+
+class CustomThemeSettingsConfigurable : SearchableConfigurable {
+
+    private var customThemeSettingsPanel : CustomThemeSettingsPanel? = null
+
+    override fun createComponent(): JComponent {
+        customThemeSettingsPanel = CustomThemeSettingsPanel()
+        OxocarbonManager.customThemeSettingsPanel = customThemeSettingsPanel
+        return customThemeSettingsPanel!!.panel
+    }
+
+    override fun getId(): String {
+        return SettingsCategory.CUSTOM_THEME.id
+    }
+
+    override fun isModified(): Boolean {
+        return false
+    }
+
+    override fun apply() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDisplayName(): String {
+        return SettingsCategory.CUSTOM_THEME.categoryName
+    }
+
+    override fun disposeUIResources() {
+        customThemeSettingsPanel = null
+    }
+}

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/configurable/OxocarbonParentSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/configurable/OxocarbonParentSettingsConfigurable.kt
@@ -11,11 +11,11 @@ class OxocarbonParentSettingsConfigurable : SearchableConfigurable, Composite {
     private var settingsParentPanel : SettingsParentPanel? = null
 
     override fun getDisplayName(): String {
-        return "Oxocarbon Settings"
+        return SettingsCategory.PARENT.categoryName
     }
 
     override fun getId(): String {
-        return "6f004dfd-8730-4721-90c6-92d762bd0ffd"
+        return SettingsCategory.PARENT.id
     }
 
     override fun createComponent(): JComponent {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -48,18 +48,22 @@
         <applicationService
                 serviceImplementation="com.github.lynxie.oxocarbon.settings.OxocarbonVersionSettings"
         />
+        <applicationService
+                serviceImplementation="com.github.lynxie.oxocarbon.settings.CustomThemeSettings"
+        />
 
         <applicationConfigurable
                 parentId="appearance"
                 instance="com.github.lynxie.oxocarbon.settings.configurable.OxocarbonParentSettingsConfigurable"
-                id="6f004dfd-8730-4721-90c6-92d762bd0ffd"
-                displayName="Oxocarbon Settings"
         />
         <applicationConfigurable
                 parentId="6f004dfd-8730-4721-90c6-92d762bd0ffd"
                 instance="com.github.lynxie.oxocarbon.settings.configurable.AppearanceSettingsConfigurable"
-                id="2ea70210-3f9b-476a-9733-87d1b9864d67"
-                displayName="Appearance"
+
+        />
+        <applicationConfigurable
+                parentId="6f004dfd-8730-4721-90c6-92d762bd0ffd"
+                instance="com.github.lynxie.oxocarbon.settings.configurable.CustomThemeSettingsConfigurable"
         />
     </extensions>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
- Added a sub-category to Oxocarbon's parent panel.
- Made sub-category additions dynamic.
  1. Previously we'd have to add each entry by hand to multiple files. Now the sub-categories load dynamically, based on what is stored within the SettingsCategory enum.
  2. Each sub-category also now dynamically attaches an Action Listener to itself, that links each of them to their respective panels.
  
After merging this PR the following issues can have their https://github.com/Oxocarbon-Theme/Oxocarbon/labels/Status%3A%20On%20Hold removed `

1. #38 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR addresses the following issues`
-  https://github.com/Oxocarbon-Theme/Oxocarbon/issues/35

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/33503fcc-20a7-4ee3-a693-a3727ed79571)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [ ] I updated the version.
- [ ] I updated the changelog with the new functionality.
